### PR TITLE
Fixes bug where Optional model fields {} default

### DIFF
--- a/gybe/__init__.py
+++ b/gybe/__init__.py
@@ -1,6 +1,6 @@
 """A simple YAML transpilation tool for rendering kubernetes manifests"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 
 from typing import List

--- a/gybe/kubernetes/io/k8s/api/admissionregistration/v1.py
+++ b/gybe/kubernetes/io/k8s/api/admissionregistration/v1.py
@@ -121,7 +121,7 @@ class MutatingWebhookConfiguration(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel22] = Field(
-        {},
+        None,
         description='Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.',
     )
     webhooks: Optional[List[MutatingWebhook]] = Field(
@@ -143,7 +143,7 @@ class MutatingWebhookConfigurationList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel19] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -201,7 +201,7 @@ class ValidatingWebhookConfiguration(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel22] = Field(
-        {},
+        None,
         description='Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.',
     )
     webhooks: Optional[List[ValidatingWebhook]] = Field(
@@ -223,6 +223,6 @@ class ValidatingWebhookConfigurationList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel19] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )

--- a/gybe/kubernetes/io/k8s/api/apiserverinternal/v1alpha1.py
+++ b/gybe/kubernetes/io/k8s/api/apiserverinternal/v1alpha1.py
@@ -31,7 +31,7 @@ class StorageVersionSpec(BaseModel):
 
 class StorageVersionCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel18] = Field(
-        {},
+        None,
         description='Last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -75,7 +75,7 @@ class StorageVersion(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel18] = Field(
-        {}, description='The name is <group>.<resource>.'
+        None, description='The name is <group>.<resource>.'
     )
     spec: StorageVersionSpec = Field(
         ...,
@@ -100,6 +100,6 @@ class StorageVersionList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel15] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/apps/v1.py
+++ b/gybe/kubernetes/io/k8s/api/apps/v1.py
@@ -27,7 +27,7 @@ class StatefulSetPersistentVolumeClaimRetentionPolicy(BaseModel):
 
 class DaemonSetCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel8] = Field(
-        {},
+        None,
         description='Last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -88,11 +88,11 @@ class DaemonSetStatus(BaseModel):
 
 class DeploymentCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel8] = Field(
-        {},
+        None,
         description='Last time the condition transitioned from one status to another.',
     )
     lastUpdateTime: Optional[v1.TimeModel8] = Field(
-        {}, description='The last time this condition was updated.'
+        None, description='The last time this condition was updated.'
     )
     message: Optional[str] = Field(
         None,
@@ -143,7 +143,7 @@ class DeploymentStatus(BaseModel):
 
 class ReplicaSetCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel8] = Field(
-        {},
+        None,
         description='The last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -221,7 +221,7 @@ class RollingUpdateStatefulSetStrategy(BaseModel):
 
 class StatefulSetCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel8] = Field(
-        {},
+        None,
         description='Last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -297,14 +297,14 @@ class ControllerRevision(BaseModel):
         description='APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources',
     )
     data: Optional[runtime.RawExtensionModel7] = Field(
-        {}, description='Data is the serialized representation of the state.'
+        None, description='Data is the serialized representation of the state.'
     )
     kind: Optional[str] = Field(
         None,
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     revision: int = Field(
@@ -326,7 +326,7 @@ class ControllerRevisionList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel7] = Field(
-        {},
+        None,
         description='More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -371,7 +371,7 @@ class DaemonSetSpec(BaseModel):
         description="An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
     )
     updateStrategy: Optional[DaemonSetUpdateStrategy] = Field(
-        {},
+        None,
         description='An update strategy to replace existing DaemonSet pods with new pods.',
     )
 
@@ -401,7 +401,7 @@ class DeploymentSpec(BaseModel):
         description="Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.",
     )
     strategy: Optional[DeploymentStrategy] = Field(
-        {},
+        None,
         description='The deployment strategy to use to replace existing pods with new ones.',
     )
     template: v1_1.PodTemplateSpec = Field(
@@ -423,7 +423,7 @@ class ReplicaSetSpec(BaseModel):
         description="Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
     )
     template: Optional[v1_1.PodTemplateSpec] = Field(
-        {},
+        None,
         description='Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template',
     )
 
@@ -464,7 +464,7 @@ class StatefulSetSpec(BaseModel):
         description='template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.',
     )
     updateStrategy: Optional[StatefulSetUpdateStrategy] = Field(
-        {},
+        None,
         description='updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.',
     )
     volumeClaimTemplates: Optional[List[v1_1.PersistentVolumeClaim]] = Field(
@@ -483,15 +483,15 @@ class DaemonSet(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[DaemonSetSpec] = Field(
-        {},
+        None,
         description='The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[DaemonSetStatus] = Field(
-        {},
+        None,
         description='The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -507,7 +507,7 @@ class DaemonSetList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel7] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -522,14 +522,14 @@ class Deployment(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[DeploymentSpec] = Field(
-        {}, description='Specification of the desired behavior of the Deployment.'
+        None, description='Specification of the desired behavior of the Deployment.'
     )
     status: Optional[DeploymentStatus] = Field(
-        {}, description='Most recently observed status of the Deployment.'
+        None, description='Most recently observed status of the Deployment.'
     )
 
 
@@ -546,7 +546,7 @@ class DeploymentList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel7] = Field(
-        {}, description='Standard list metadata.'
+        None, description='Standard list metadata.'
     )
 
 
@@ -560,15 +560,15 @@ class ReplicaSet(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description="If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[ReplicaSetSpec] = Field(
-        {},
+        None,
         description='Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[ReplicaSetStatus] = Field(
-        {},
+        None,
         description='Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -587,7 +587,7 @@ class ReplicaSetList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel7] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -602,14 +602,14 @@ class StatefulSet(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[StatefulSetSpec] = Field(
-        {}, description='Spec defines the desired identities of pods in this set.'
+        None, description='Spec defines the desired identities of pods in this set.'
     )
     status: Optional[StatefulSetStatus] = Field(
-        {},
+        None,
         description='Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.',
     )
 
@@ -627,6 +627,6 @@ class StatefulSetList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel7] = Field(
-        {},
+        None,
         description="Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )

--- a/gybe/kubernetes/io/k8s/api/authentication/v1.py
+++ b/gybe/kubernetes/io/k8s/api/authentication/v1.py
@@ -98,7 +98,7 @@ class TokenReviewStatus(BaseModel):
         None, description="Error indicates that the token couldn't be checked"
     )
     user: Optional[UserInfoModel] = Field(
-        {}, description='User is the UserInfo associated with the provided token.'
+        None, description='User is the UserInfo associated with the provided token.'
     )
 
 
@@ -112,14 +112,14 @@ class TokenRequest(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: TokenRequestSpec = Field(
         ..., description='Spec holds information about the request being evaluated'
     )
     status: Optional[TokenRequestStatus] = Field(
-        {},
+        None,
         description='Status is filled in by the server and indicates whether the token can be authenticated.',
     )
 
@@ -134,13 +134,13 @@ class TokenReview(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel17] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: TokenReviewSpec = Field(
         ..., description='Spec holds information about the request being evaluated'
     )
     status: Optional[TokenReviewStatus] = Field(
-        {},
+        None,
         description='Status is filled in by the server and indicates whether the request can be authenticated.',
     )

--- a/gybe/kubernetes/io/k8s/api/authentication/v1alpha1.py
+++ b/gybe/kubernetes/io/k8s/api/authentication/v1alpha1.py
@@ -14,7 +14,7 @@ from . import v1
 
 class SelfSubjectReviewStatus(BaseModel):
     userInfo: Optional[v1.UserInfo] = Field(
-        {}, description='User attributes of the user making this request.'
+        None, description='User attributes of the user making this request.'
     )
 
 
@@ -28,9 +28,9 @@ class SelfSubjectReview(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel7] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     status: Optional[SelfSubjectReviewStatus] = Field(
-        {}, description='Status is filled in by the server with the user attributes.'
+        None, description='Status is filled in by the server with the user attributes.'
     )

--- a/gybe/kubernetes/io/k8s/api/authorization/v1.py
+++ b/gybe/kubernetes/io/k8s/api/authorization/v1.py
@@ -165,7 +165,7 @@ class LocalSubjectAccessReview(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel13] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: SubjectAccessReviewSpec = Field(
@@ -173,7 +173,7 @@ class LocalSubjectAccessReview(BaseModel):
         description='Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.',
     )
     status: Optional[SubjectAccessReviewStatus] = Field(
-        {},
+        None,
         description='Status is filled in by the server and indicates whether the request is allowed or not',
     )
 
@@ -188,7 +188,7 @@ class SelfSubjectAccessReview(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel13] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: SelfSubjectAccessReviewSpec = Field(
@@ -196,7 +196,7 @@ class SelfSubjectAccessReview(BaseModel):
         description='Spec holds information about the request being evaluated.  user and groups must be empty',
     )
     status: Optional[SubjectAccessReviewStatus] = Field(
-        {},
+        None,
         description='Status is filled in by the server and indicates whether the request is allowed or not',
     )
 
@@ -211,14 +211,14 @@ class SelfSubjectRulesReview(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel13] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: SelfSubjectRulesReviewSpec = Field(
         ..., description='Spec holds information about the request being evaluated.'
     )
     status: Optional[SubjectRulesReviewStatus] = Field(
-        {},
+        None,
         description='Status is filled in by the server and indicates the set of actions a user can perform.',
     )
 
@@ -233,13 +233,13 @@ class SubjectAccessReview(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel13] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: SubjectAccessReviewSpec = Field(
         ..., description='Spec holds information about the request being evaluated'
     )
     status: Optional[SubjectAccessReviewStatus] = Field(
-        {},
+        None,
         description='Status is filled in by the server and indicates whether the request is allowed or not',
     )

--- a/gybe/kubernetes/io/k8s/api/autoscaling/v1.py
+++ b/gybe/kubernetes/io/k8s/api/autoscaling/v1.py
@@ -106,15 +106,15 @@ class Scale(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description='Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.',
     )
     spec: Optional[ScaleSpec] = Field(
-        {},
+        None,
         description='defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.',
     )
     status: Optional[ScaleStatus] = Field(
-        {},
+        None,
         description='current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.',
     )
 
@@ -129,15 +129,15 @@ class HorizontalPodAutoscaler(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel9] = Field(
-        {},
+        None,
         description='Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: Optional[HorizontalPodAutoscalerSpec] = Field(
-        {},
+        None,
         description='behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.',
     )
     status: Optional[HorizontalPodAutoscalerStatus] = Field(
-        {}, description='current information about the autoscaler.'
+        None, description='current information about the autoscaler.'
     )
 
 
@@ -154,7 +154,7 @@ class HorizontalPodAutoscalerList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel8] = Field(
-        {}, description='Standard list metadata.'
+        None, description='Standard list metadata.'
     )
 
 
@@ -168,14 +168,14 @@ class ScaleModel(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description='Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.',
     )
     spec: Optional[ScaleSpecModel] = Field(
-        {},
+        None,
         description='defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.',
     )
     status: Optional[ScaleStatusModel] = Field(
-        {},
+        None,
         description='current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.',
     )

--- a/gybe/kubernetes/io/k8s/api/autoscaling/v2.py
+++ b/gybe/kubernetes/io/k8s/api/autoscaling/v2.py
@@ -64,7 +64,7 @@ class HorizontalPodAutoscalerBehavior(BaseModel):
 
 class HorizontalPodAutoscalerCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel16] = Field(
-        {},
+        None,
         description='lastTransitionTime is the last time the condition transitioned from one status to another',
     )
     message: Optional[str] = Field(
@@ -332,15 +332,15 @@ class HorizontalPodAutoscaler(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel16] = Field(
-        {},
+        None,
         description='metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: Optional[HorizontalPodAutoscalerSpec] = Field(
-        {},
+        None,
         description='spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.',
     )
     status: Optional[HorizontalPodAutoscalerStatus] = Field(
-        {}, description='status is the current information about the autoscaler.'
+        None, description='status is the current information about the autoscaler.'
     )
 
 
@@ -357,5 +357,5 @@ class HorizontalPodAutoscalerList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel14] = Field(
-        {}, description='metadata is the standard list metadata.'
+        None, description='metadata is the standard list metadata.'
     )

--- a/gybe/kubernetes/io/k8s/api/batch/v1.py
+++ b/gybe/kubernetes/io/k8s/api/batch/v1.py
@@ -77,10 +77,10 @@ class CronJobStatus(BaseModel):
 
 class JobCondition(BaseModel):
     lastProbeTime: Optional[v1_1.TimeModel21] = Field(
-        {}, description='Last time the condition was checked.'
+        None, description='Last time the condition was checked.'
     )
     lastTransitionTime: Optional[v1_1.TimeModel21] = Field(
-        {}, description='Last time the condition transit from one status to another.'
+        None, description='Last time the condition transit from one status to another.'
     )
     message: Optional[str] = Field(
         None,
@@ -187,11 +187,11 @@ class JobSpec(BaseModel):
 
 class JobTemplateSpec(BaseModel):
     metadata: Optional[v1_1.ObjectMetaModel21] = Field(
-        {},
+        None,
         description="Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[JobSpec] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -241,15 +241,15 @@ class Job(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel21] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[JobSpec] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[JobStatus] = Field(
-        {},
+        None,
         description='Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -265,7 +265,7 @@ class JobList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel18] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -280,15 +280,15 @@ class CronJob(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel21] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[CronJobSpec] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[CronJobStatus] = Field(
-        {},
+        None,
         description='Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -304,6 +304,6 @@ class CronJobList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel18] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/certificates/v1.py
+++ b/gybe/kubernetes/io/k8s/api/certificates/v1.py
@@ -48,11 +48,11 @@ class CertificateSigningRequestSpec(BaseModel):
 
 class CertificateSigningRequestCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel15] = Field(
-        {},
+        None,
         description="lastTransitionTime is the time the condition last transitioned from one status to another. If unset, when a new condition type is added or an existing condition's status is changed, the server defaults this to the current time.",
     )
     lastUpdateTime: Optional[v1.TimeModel15] = Field(
-        {},
+        None,
         description='lastUpdateTime is the time of the last update to this condition',
     )
     message: Optional[str] = Field(
@@ -98,7 +98,7 @@ class CertificateSigningRequest(BaseModel):
         description='spec contains the certificate request, and is immutable after creation. Only the request, signerName, expirationSeconds, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users.',
     )
     status: Optional[CertificateSigningRequestStatus] = Field(
-        {},
+        None,
         description='status contains information about whether the request is approved or denied, and the certificate issued by the signer, or the failure condition indicating signer failure.',
     )
 

--- a/gybe/kubernetes/io/k8s/api/coordination/v1.py
+++ b/gybe/kubernetes/io/k8s/api/coordination/v1.py
@@ -43,11 +43,11 @@ class Lease(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel5] = Field(
-        {},
+        None,
         description='More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: Optional[LeaseSpec] = Field(
-        {},
+        None,
         description='Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -63,6 +63,6 @@ class LeaseList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel5] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/core/v1.py
+++ b/gybe/kubernetes/io/k8s/api/core/v1.py
@@ -1559,7 +1559,7 @@ class NodeConfigStatus(BaseModel):
 
 class NodeDaemonEndpoints(BaseModel):
     kubeletEndpoint: Optional[DaemonEndpoint] = Field(
-        {}, description='Endpoint on which Kubelet is listening.'
+        None, description='Endpoint on which Kubelet is listening.'
     )
 
 
@@ -3376,10 +3376,10 @@ class NodeSelectorModel1(BaseModel):
 
 class PersistentVolumeClaimCondition(BaseModel):
     lastProbeTime: Optional[v1.TimeModel8] = Field(
-        {}, description='lastProbeTime is the time we probed the condition.'
+        None, description='lastProbeTime is the time we probed the condition.'
     )
     lastTransitionTime: Optional[v1.TimeModel8] = Field(
-        {},
+        None,
         description='lastTransitionTime is the time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -3484,7 +3484,7 @@ class ResourceFieldSelector(BaseModel):
         None, description='Container name: required for volumes, optional for env vars'
     )
     divisor: Optional[resource.QuantityModel1] = Field(
-        {},
+        None,
         description='Specifies the output format of the exposed resources, defaults to "1"',
     )
     resource: str = Field(..., description='Required: resource to select')
@@ -3751,7 +3751,7 @@ class ConfigMapVolumeSourceModel(BaseModel):
 
 class ContainerStateRunning(BaseModel):
     startedAt: Optional[v1.TimeModel10] = Field(
-        {}, description='Time at which the container was last (re-)started'
+        None, description='Time at which the container was last (re-)started'
     )
 
 
@@ -3763,7 +3763,7 @@ class ContainerStateTerminated(BaseModel):
         ..., description='Exit status from the last termination of the container'
     )
     finishedAt: Optional[v1.TimeModel10] = Field(
-        {}, description='Time at which the container last terminated'
+        None, description='Time at which the container last terminated'
     )
     message: Optional[str] = Field(
         None, description='Message regarding the last termination of the container'
@@ -3775,7 +3775,7 @@ class ContainerStateTerminated(BaseModel):
         None, description='Signal from the last termination of the container'
     )
     startedAt: Optional[v1.TimeModel10] = Field(
-        {}, description='Time at which previous execution of the container started'
+        None, description='Time at which previous execution of the container started'
     )
 
 
@@ -3838,7 +3838,7 @@ class EventSeries(BaseModel):
         description='Number of occurrences in this series up to the last heartbeat time',
     )
     lastObservedTime: Optional[v1.MicroTimeModel1] = Field(
-        {}, description='Time of the last occurrence observed'
+        None, description='Time of the last occurrence observed'
     )
 
 
@@ -4062,10 +4062,10 @@ class NamespaceStatus(BaseModel):
 
 class NodeCondition(BaseModel):
     lastHeartbeatTime: Optional[v1.TimeModel10] = Field(
-        {}, description='Last time we got an update on a given condition.'
+        None, description='Last time we got an update on a given condition.'
     )
     lastTransitionTime: Optional[v1.TimeModel10] = Field(
-        {}, description='Last time the condition transit from one status to another.'
+        None, description='Last time the condition transit from one status to another.'
     )
     message: Optional[str] = Field(
         None,
@@ -4108,13 +4108,13 @@ class NodeStatus(BaseModel):
         description='Status of the config assigned to the node via the dynamic Kubelet config feature.',
     )
     daemonEndpoints: Optional[NodeDaemonEndpoints] = Field(
-        {}, description='Endpoints of daemons running on the Node.'
+        None, description='Endpoints of daemons running on the Node.'
     )
     images: Optional[List[ContainerImage]] = Field(
         None, description='List of container images on this node'
     )
     nodeInfo: Optional[NodeSystemInfo] = Field(
-        {},
+        None,
         description='Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info',
     )
     phase: Optional[str] = Field(
@@ -4131,10 +4131,10 @@ class NodeStatus(BaseModel):
 
 class PersistentVolumeClaimConditionModel(BaseModel):
     lastProbeTime: Optional[v1.TimeModel10] = Field(
-        {}, description='lastProbeTime is the time we probed the condition.'
+        None, description='lastProbeTime is the time we probed the condition.'
     )
     lastTransitionTime: Optional[v1.TimeModel10] = Field(
-        {},
+        None,
         description='lastTransitionTime is the time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -4178,10 +4178,10 @@ class PersistentVolumeClaimStatusModel(BaseModel):
 
 class PodCondition(BaseModel):
     lastProbeTime: Optional[v1.TimeModel10] = Field(
-        {}, description='Last time we probed the condition.'
+        None, description='Last time we probed the condition.'
     )
     lastTransitionTime: Optional[v1.TimeModel10] = Field(
-        {},
+        None,
         description='Last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -4297,7 +4297,7 @@ class RBDPersistentVolumeSourceModel(BaseModel):
 
 class ReplicationControllerCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel10] = Field(
-        {},
+        None,
         description='The last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -4345,7 +4345,7 @@ class ResourceFieldSelectorModel(BaseModel):
         None, description='Container name: required for volumes, optional for env vars'
     )
     divisor: Optional[resource.QuantityModel2] = Field(
-        {},
+        None,
         description='Specifies the output format of the exposed resources, defaults to "1"',
     )
     resource: str = Field(..., description='Required: resource to select')
@@ -4488,7 +4488,7 @@ class ServicePort(BaseModel):
         description='The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.\n\n',
     )
     targetPort: Optional[intstr.IntOrStringModel] = Field(
-        {},
+        None,
         description="Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
     )
 
@@ -4906,7 +4906,7 @@ class ResourceFieldSelectorModel1(BaseModel):
         None, description='Container name: required for volumes, optional for env vars'
     )
     divisor: Optional[resource.QuantityModel5] = Field(
-        {},
+        None,
         description='Specifies the output format of the exposed resources, defaults to "1"',
     )
     resource: str = Field(..., description='Required: resource to select')
@@ -5191,7 +5191,7 @@ class PersistentVolumeClaimSpec(BaseModel):
         description='dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While DataSource ignores disallowed values (dropping them), DataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.',
     )
     resources: Optional[ResourceRequirements] = Field(
-        {},
+        None,
         description='resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources',
     )
     selector: Optional[v1.LabelSelectorModel1] = Field(
@@ -5214,7 +5214,7 @@ class PersistentVolumeClaimSpec(BaseModel):
 
 class PersistentVolumeClaimTemplate(BaseModel):
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description='May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.',
     )
     spec: PersistentVolumeClaimSpec = Field(
@@ -5337,7 +5337,7 @@ class Binding(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     target: ObjectReferenceModel1 = Field(
@@ -5359,7 +5359,7 @@ class ComponentStatus(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
 
@@ -5377,7 +5377,7 @@ class ComponentStatusList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -5404,7 +5404,7 @@ class ConfigMap(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
 
@@ -5420,7 +5420,7 @@ class ConfigMapList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -5447,7 +5447,7 @@ class ContainerStatus(BaseModel):
     )
     imageID: str = Field(..., description="ImageID of the container's image.")
     lastState: Optional[ContainerState] = Field(
-        {}, description="Details about the container's last termination condition."
+        None, description="Details about the container's last termination condition."
     )
     name: str = Field(
         ...,
@@ -5465,7 +5465,7 @@ class ContainerStatus(BaseModel):
         description='Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.',
     )
     state: Optional[ContainerState] = Field(
-        {}, description="Details about the container's current condition."
+        None, description="Details about the container's current condition."
     )
 
 
@@ -5508,7 +5508,7 @@ class Endpoints(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     subsets: Optional[List[EndpointSubset]] = Field(
@@ -5528,7 +5528,7 @@ class EndpointsList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -5563,10 +5563,10 @@ class Event(BaseModel):
         None, description='The number of times this event has occurred.'
     )
     eventTime: Optional[v1.MicroTimeModel1] = Field(
-        {}, description='Time when this Event was first observed.'
+        None, description='Time when this Event was first observed.'
     )
     firstTimestamp: Optional[v1.TimeModel10] = Field(
-        {},
+        None,
         description='The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)',
     )
     involvedObject: ObjectReferenceModel1 = Field(
@@ -5577,7 +5577,7 @@ class Event(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     lastTimestamp: Optional[v1.TimeModel10] = Field(
-        {},
+        None,
         description='The time at which the most recent occurrence of this event was recorded.',
     )
     message: Optional[str] = Field(
@@ -5607,7 +5607,7 @@ class Event(BaseModel):
         description="Data about the Event series this event represents or nil if it's a singleton Event.",
     )
     source: Optional[EventSourceModel] = Field(
-        {},
+        None,
         description='The component reporting this event. Should be a short machine understandable string.',
     )
     type: Optional[str] = Field(
@@ -5627,7 +5627,7 @@ class EventList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -5655,11 +5655,11 @@ class LimitRange(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[LimitRangeSpec] = Field(
-        {},
+        None,
         description='Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -5678,7 +5678,7 @@ class LimitRangeList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -5693,15 +5693,15 @@ class Namespace(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[NamespaceSpec] = Field(
-        {},
+        None,
         description='Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[NamespaceStatus] = Field(
-        {},
+        None,
         description='Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -5720,7 +5720,7 @@ class NamespaceList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -5783,7 +5783,7 @@ class PersistentVolumeClaimSpecModel(BaseModel):
         description='dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While DataSource ignores disallowed values (dropping them), DataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.',
     )
     resources: Optional[ResourceRequirementsModel] = Field(
-        {},
+        None,
         description='resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources',
     )
     selector: Optional[v1.LabelSelectorModel2] = Field(
@@ -5806,7 +5806,7 @@ class PersistentVolumeClaimSpecModel(BaseModel):
 
 class PersistentVolumeClaimTemplateModel(BaseModel):
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description='May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.',
     )
     spec: PersistentVolumeClaimSpecModel = Field(
@@ -6084,7 +6084,7 @@ class Secret(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     stringData: Optional[Dict[str, str]] = Field(
@@ -6111,7 +6111,7 @@ class SecretList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -6134,7 +6134,7 @@ class ServiceAccount(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     secrets: Optional[List[ObjectReferenceModel1]] = Field(
@@ -6157,7 +6157,7 @@ class ServiceAccountList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -6167,7 +6167,7 @@ class ServiceStatus(BaseModel):
         None, description='Current service state'
     )
     loadBalancer: Optional[LoadBalancerStatus] = Field(
-        {},
+        None,
         description='LoadBalancer contains the current status of the load-balancer, if one is present.',
     )
 
@@ -6306,7 +6306,7 @@ class PersistentVolumeClaimSpecModel1(BaseModel):
         description='dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While DataSource ignores disallowed values (dropping them), DataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.',
     )
     resources: Optional[ResourceRequirementsModel1] = Field(
-        {},
+        None,
         description='resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources',
     )
     selector: Optional[v1.LabelSelectorModel7] = Field(
@@ -6329,7 +6329,7 @@ class PersistentVolumeClaimSpecModel1(BaseModel):
 
 class PersistentVolumeClaimTemplateModel1(BaseModel):
     metadata: Optional[v1.ObjectMetaModel21] = Field(
-        {},
+        None,
         description='May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.',
     )
     spec: PersistentVolumeClaimSpecModel1 = Field(
@@ -6490,15 +6490,15 @@ class PersistentVolumeClaim(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PersistentVolumeClaimSpec] = Field(
-        {},
+        None,
         description='spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims',
     )
     status: Optional[PersistentVolumeClaimStatus] = Field(
-        {},
+        None,
         description='status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims',
     )
 
@@ -6598,15 +6598,15 @@ class Node(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[NodeSpec] = Field(
-        {},
+        None,
         description='Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[NodeStatus] = Field(
-        {},
+        None,
         description='Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -6622,7 +6622,7 @@ class NodeList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -6637,15 +6637,15 @@ class PersistentVolume(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PersistentVolumeSpecModel] = Field(
-        {},
+        None,
         description='spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes',
     )
     status: Optional[PersistentVolumeStatus] = Field(
-        {},
+        None,
         description='status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes',
     )
 
@@ -6660,15 +6660,15 @@ class PersistentVolumeClaimModel(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PersistentVolumeClaimSpecModel] = Field(
-        {},
+        None,
         description='spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims',
     )
     status: Optional[PersistentVolumeClaimStatusModel] = Field(
-        {},
+        None,
         description='status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims',
     )
 
@@ -6687,7 +6687,7 @@ class PersistentVolumeClaimList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -6706,7 +6706,7 @@ class PersistentVolumeList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -6751,15 +6751,15 @@ class ResourceQuota(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[ResourceQuotaSpec] = Field(
-        {},
+        None,
         description='Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[ResourceQuotaStatus] = Field(
-        {},
+        None,
         description='Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -6778,7 +6778,7 @@ class ResourceQuotaList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -6793,15 +6793,15 @@ class Service(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[ServiceSpec] = Field(
-        {},
+        None,
         description='Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[ServiceStatus] = Field(
-        {},
+        None,
         description='Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -6817,7 +6817,7 @@ class ServiceList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -6984,7 +6984,7 @@ class Container(BaseModel):
         description='Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes',
     )
     resources: Optional[ResourceRequirements] = Field(
-        {},
+        None,
         description='Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/',
     )
     securityContext: Optional[SecurityContext] = Field(
@@ -7071,7 +7071,7 @@ class EphemeralContainer(BaseModel):
         None, description='Probes are not allowed for ephemeral containers.'
     )
     resources: Optional[ResourceRequirements] = Field(
-        {},
+        None,
         description='Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.',
     )
     securityContext: Optional[SecurityContext] = Field(
@@ -7312,7 +7312,7 @@ class ContainerModel(BaseModel):
         description='Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes',
     )
     resources: Optional[ResourceRequirementsModel] = Field(
-        {},
+        None,
         description='Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/',
     )
     securityContext: Optional[SecurityContextModel] = Field(
@@ -7399,7 +7399,7 @@ class EphemeralContainerModel(BaseModel):
         None, description='Probes are not allowed for ephemeral containers.'
     )
     resources: Optional[ResourceRequirementsModel] = Field(
-        {},
+        None,
         description='Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.',
     )
     securityContext: Optional[SecurityContextModel] = Field(
@@ -7640,7 +7640,7 @@ class ContainerModel1(BaseModel):
         description='Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes',
     )
     resources: Optional[ResourceRequirementsModel1] = Field(
-        {},
+        None,
         description='Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/',
     )
     securityContext: Optional[SecurityContextModel1] = Field(
@@ -7727,7 +7727,7 @@ class EphemeralContainerModel1(BaseModel):
         None, description='Probes are not allowed for ephemeral containers.'
     )
     resources: Optional[ResourceRequirementsModel1] = Field(
-        {},
+        None,
         description='Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.',
     )
     securityContext: Optional[SecurityContextModel1] = Field(
@@ -8057,11 +8057,11 @@ class PodSpec(BaseModel):
 
 class PodTemplateSpec(BaseModel):
     metadata: Optional[v1.ObjectMetaModel8] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PodSpec] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -8215,11 +8215,11 @@ class PodSpecModel(BaseModel):
 
 class PodTemplateSpecModel(BaseModel):
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PodSpecModel] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -8392,11 +8392,11 @@ class PodSpecModel1(BaseModel):
 
 class PodTemplateSpecModel1(BaseModel):
     metadata: Optional[v1.ObjectMetaModel21] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PodSpecModel1] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -8411,15 +8411,15 @@ class Pod(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PodSpecModel] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[PodStatus] = Field(
-        {},
+        None,
         description='Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -8438,7 +8438,7 @@ class PodList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -8453,11 +8453,11 @@ class PodTemplate(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     template: Optional[PodTemplateSpecModel] = Field(
-        {},
+        None,
         description='Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -8473,7 +8473,7 @@ class PodTemplateList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
 
@@ -8488,15 +8488,15 @@ class ReplicationController(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {},
+        None,
         description="If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[ReplicationControllerSpec] = Field(
-        {},
+        None,
         description='Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[ReplicationControllerStatus] = Field(
-        {},
+        None,
         description='Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -8515,6 +8515,6 @@ class ReplicationControllerList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )

--- a/gybe/kubernetes/io/k8s/api/discovery/v1.py
+++ b/gybe/kubernetes/io/k8s/api/discovery/v1.py
@@ -63,7 +63,7 @@ class Endpoint(BaseModel):
         description='addresses of this endpoint. The contents of this field are interpreted according to the corresponding EndpointSlice addressType field. Consumers must handle different types of addresses in the context of their own capabilities. This must contain at least one address but no more than 100. These are all assumed to be fungible and clients may choose to only use the first element. Refer to: https://issue.k8s.io/106267',
     )
     conditions: Optional[EndpointConditions] = Field(
-        {},
+        None,
         description='conditions contains information about the current status of the endpoint.',
     )
     deprecatedTopology: Optional[Dict[str, str]] = Field(
@@ -109,7 +109,7 @@ class EndpointSlice(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel20] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
     ports: Optional[List[EndpointPort]] = Field(
         None,
@@ -128,5 +128,5 @@ class EndpointSliceList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel17] = Field(
-        {}, description='Standard list metadata.'
+        None, description='Standard list metadata.'
     )

--- a/gybe/kubernetes/io/k8s/api/events/v1.py
+++ b/gybe/kubernetes/io/k8s/api/events/v1.py
@@ -37,15 +37,15 @@ class Event(BaseModel):
         description='deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.',
     )
     deprecatedFirstTimestamp: Optional[v1.Time] = Field(
-        {},
+        None,
         description='deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.',
     )
     deprecatedLastTimestamp: Optional[v1.Time] = Field(
-        {},
+        None,
         description='deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.',
     )
     deprecatedSource: Optional[v1_1.EventSource] = Field(
-        {},
+        None,
         description='deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.',
     )
     eventTime: v1.MicroTime = Field(
@@ -57,7 +57,7 @@ class Event(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMeta] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     note: Optional[str] = Field(
@@ -69,7 +69,7 @@ class Event(BaseModel):
         description='reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.',
     )
     regarding: Optional[v1_1.ObjectReference] = Field(
-        {},
+        None,
         description="regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.",
     )
     related: Optional[v1_1.ObjectReference] = Field(
@@ -105,6 +105,6 @@ class EventList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMeta] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/flowcontrol/v1beta2.py
+++ b/gybe/kubernetes/io/k8s/api/flowcontrol/v1beta2.py
@@ -101,7 +101,7 @@ class UserSubject(BaseModel):
 
 class FlowSchemaCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel6] = Field(
-        {},
+        None,
         description='`lastTransitionTime` is the last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -144,14 +144,14 @@ class LimitedPriorityLevelConfiguration(BaseModel):
         description="`assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:\n\n            ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )\n\nbigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.",
     )
     limitResponse: Optional[LimitResponse] = Field(
-        {},
+        None,
         description='`limitResponse` indicates what to do with requests that can not be executed right now',
     )
 
 
 class PriorityLevelConfigurationCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel6] = Field(
-        {},
+        None,
         description='`lastTransitionTime` is the last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -229,15 +229,15 @@ class PriorityLevelConfiguration(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel6] = Field(
-        {},
+        None,
         description="`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PriorityLevelConfigurationSpec] = Field(
-        {},
+        None,
         description='`spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[PriorityLevelConfigurationStatus] = Field(
-        {},
+        None,
         description='`status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -255,7 +255,7 @@ class PriorityLevelConfigurationList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel6] = Field(
-        {},
+        None,
         description="`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
 
@@ -289,15 +289,15 @@ class FlowSchema(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel6] = Field(
-        {},
+        None,
         description="`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[FlowSchemaSpec] = Field(
-        {},
+        None,
         description='`spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[FlowSchemaStatus] = Field(
-        {},
+        None,
         description='`status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -315,6 +315,6 @@ class FlowSchemaList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel6] = Field(
-        {},
+        None,
         description='`metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/networking/v1.py
+++ b/gybe/kubernetes/io/k8s/api/networking/v1.py
@@ -81,14 +81,14 @@ class IngressServiceBackend(BaseModel):
         description='Name is the referenced service. The service must exist in the same namespace as the Ingress object.',
     )
     port: Optional[ServiceBackendPort] = Field(
-        {},
+        None,
         description='Port of the referenced service. A port name or port number is required for a IngressServiceBackend.',
     )
 
 
 class IngressStatus(BaseModel):
     loadBalancer: Optional[v1.LoadBalancerStatusModel] = Field(
-        {}, description='LoadBalancer contains the current status of the load-balancer.'
+        None, description='LoadBalancer contains the current status of the load-balancer.'
     )
 
 
@@ -128,11 +128,11 @@ class IngressClass(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel14] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[IngressClassSpec] = Field(
-        {},
+        None,
         description='Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -150,7 +150,7 @@ class IngressClassList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel12] = Field(
-        {}, description='Standard list metadata.'
+        None, description='Standard list metadata.'
     )
 
 
@@ -276,15 +276,15 @@ class Ingress(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel14] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[IngressSpec] = Field(
-        {},
+        None,
         description='Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
     status: Optional[IngressStatus] = Field(
-        {},
+        None,
         description='Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -300,7 +300,7 @@ class IngressList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel12] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
 
@@ -315,14 +315,14 @@ class NetworkPolicy(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel14] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[NetworkPolicySpec] = Field(
-        {}, description='Specification of the desired behavior for this NetworkPolicy.'
+        None, description='Specification of the desired behavior for this NetworkPolicy.'
     )
     status: Optional[NetworkPolicyStatus] = Field(
-        {},
+        None,
         description='Status is the current state of the NetworkPolicy. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -340,6 +340,6 @@ class NetworkPolicyList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel12] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/networking/v1alpha1.py
+++ b/gybe/kubernetes/io/k8s/api/networking/v1alpha1.py
@@ -41,11 +41,11 @@ class ClusterCIDR(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel2] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[ClusterCIDRSpec] = Field(
-        {},
+        None,
         description='Spec is the desired state of the ClusterCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status',
     )
 
@@ -63,6 +63,6 @@ class ClusterCIDRList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel2] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )

--- a/gybe/kubernetes/io/k8s/api/node/v1.py
+++ b/gybe/kubernetes/io/k8s/api/node/v1.py
@@ -45,7 +45,7 @@ class RuntimeClass(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ObjectMetaModel3] = Field(
-        {},
+        None,
         description='More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     overhead: Optional[Overhead] = Field(
@@ -71,6 +71,6 @@ class RuntimeClassList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1_1.ListMetaModel3] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/policy/v1.py
+++ b/gybe/kubernetes/io/k8s/api/policy/v1.py
@@ -25,7 +25,7 @@ class Eviction(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel10] = Field(
-        {}, description='ObjectMeta describes the pod that is being evicted.'
+        None, description='ObjectMeta describes the pod that is being evicted.'
     )
 
 
@@ -79,15 +79,15 @@ class PodDisruptionBudget(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel11] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: Optional[PodDisruptionBudgetSpec] = Field(
-        {},
+        None,
         description='Specification of the desired behavior of the PodDisruptionBudget.',
     )
     status: Optional[PodDisruptionBudgetStatus] = Field(
-        {}, description='Most recently observed status of the PodDisruptionBudget.'
+        None, description='Most recently observed status of the PodDisruptionBudget.'
     )
 
 
@@ -104,6 +104,6 @@ class PodDisruptionBudgetList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel10] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )

--- a/gybe/kubernetes/io/k8s/api/rbac/v1.py
+++ b/gybe/kubernetes/io/k8s/api/rbac/v1.py
@@ -79,7 +79,7 @@ class ClusterRole(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
     rules: Optional[List[PolicyRule]] = Field(
         None, description='Rules holds all the PolicyRules for this ClusterRole'
@@ -96,7 +96,7 @@ class ClusterRoleBinding(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
     roleRef: RoleRef = Field(
         ...,
@@ -121,7 +121,7 @@ class ClusterRoleBindingList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
 
 
@@ -136,7 +136,7 @@ class ClusterRoleList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
 
 
@@ -150,7 +150,7 @@ class Role(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
     rules: Optional[List[PolicyRule]] = Field(
         None, description='Rules holds all the PolicyRules for this Role'
@@ -167,7 +167,7 @@ class RoleBinding(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
     roleRef: RoleRef = Field(
         ...,
@@ -190,7 +190,7 @@ class RoleBindingList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )
 
 
@@ -205,5 +205,5 @@ class RoleList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel4] = Field(
-        {}, description="Standard object's metadata."
+        None, description="Standard object's metadata."
     )

--- a/gybe/kubernetes/io/k8s/api/scheduling/v1.py
+++ b/gybe/kubernetes/io/k8s/api/scheduling/v1.py
@@ -29,7 +29,7 @@ class PriorityClass(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel12] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     preemptionPolicy: Optional[str] = Field(
@@ -55,6 +55,6 @@ class PriorityClassList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel11] = Field(
-        {},
+        None,
         description='Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/storage/v1.py
+++ b/gybe/kubernetes/io/k8s/api/storage/v1.py
@@ -98,7 +98,7 @@ class VolumeError(BaseModel):
         description='String detailing the error encountered during Attach or Detach operation. This string may be logged, so it should not contain sensitive information.',
     )
     time: Optional[v1.TimeModel] = Field(
-        {}, description='Time the error was encountered.'
+        None, description='Time the error was encountered.'
     )
 
 
@@ -112,7 +112,7 @@ class CSIDriver(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel] = Field(
-        {},
+        None,
         description='Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: CSIDriverSpec = Field(..., description='Specification of the CSI Driver.')
@@ -129,7 +129,7 @@ class CSIDriverList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel] = Field(
-        {},
+        None,
         description='Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -144,7 +144,7 @@ class CSINode(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel] = Field(
-        {}, description='metadata.name must be the Kubernetes node name.'
+        None, description='metadata.name must be the Kubernetes node name.'
     )
     spec: CSINodeSpec = Field(..., description='spec is the specification of CSINode')
 
@@ -160,7 +160,7 @@ class CSINodeList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel] = Field(
-        {},
+        None,
         description='Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -183,7 +183,7 @@ class CSIStorageCapacity(BaseModel):
         description='MaximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.\n\nThis is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.',
     )
     metadata: Optional[v1.ObjectMetaModel] = Field(
-        {},
+        None,
         description="Standard object's metadata. The name has no particular meaning. It must be be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.\n\nObjects are namespaced.\n\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     nodeTopology: Optional[v1.LabelSelector] = Field(
@@ -209,7 +209,7 @@ class CSIStorageCapacityList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel] = Field(
-        {},
+        None,
         description='Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -232,7 +232,7 @@ class StorageClass(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel] = Field(
-        {},
+        None,
         description="Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     mountOptions: Optional[List[str]] = Field(
@@ -269,7 +269,7 @@ class StorageClassList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel] = Field(
-        {},
+        None,
         description='Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
 
@@ -326,7 +326,7 @@ class VolumeAttachment(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel] = Field(
-        {},
+        None,
         description='Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     spec: VolumeAttachmentSpec = Field(
@@ -334,7 +334,7 @@ class VolumeAttachment(BaseModel):
         description='Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.',
     )
     status: Optional[VolumeAttachmentStatus] = Field(
-        {},
+        None,
         description='Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.',
     )
 
@@ -352,6 +352,6 @@ class VolumeAttachmentList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel] = Field(
-        {},
+        None,
         description='Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/api/storage/v1beta1.py
+++ b/gybe/kubernetes/io/k8s/api/storage/v1beta1.py
@@ -30,7 +30,7 @@ class CSIStorageCapacity(BaseModel):
         description='MaximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.\n\nThis is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.',
     )
     metadata: Optional[v1.ObjectMetaModel19] = Field(
-        {},
+        None,
         description="Standard object's metadata. The name has no particular meaning. It must be be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.\n\nObjects are namespaced.\n\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     nodeTopology: Optional[v1.LabelSelectorModel6] = Field(
@@ -56,6 +56,6 @@ class CSIStorageCapacityList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel16] = Field(
-        {},
+        None,
         description='Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )

--- a/gybe/kubernetes/io/k8s/apiextensions_apiserver/pkg/apis/apiextensions/v1.py
+++ b/gybe/kubernetes/io/k8s/apiextensions_apiserver/pkg/apis/apiextensions/v1.py
@@ -99,7 +99,7 @@ class ExternalDocumentation(BaseModel):
 class JSON(BaseModel):
     __root__: Any = Field(
         ...,
-        description='JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.',
+        description='JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interfaceNone, map[string]interface{} and nil.',
     )
 
 
@@ -189,7 +189,7 @@ class CustomResourceConversion(BaseModel):
 
 class CustomResourceDefinitionCondition(BaseModel):
     lastTransitionTime: Optional[v1.TimeModel1] = Field(
-        {},
+        None,
         description='lastTransitionTime last time the condition transitioned from one status to another.',
     )
     message: Optional[str] = Field(
@@ -212,7 +212,7 @@ class CustomResourceDefinitionCondition(BaseModel):
 
 class CustomResourceDefinitionStatus(BaseModel):
     acceptedNames: Optional[CustomResourceDefinitionNames] = Field(
-        {},
+        None,
         description='acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.',
     )
     conditions: Optional[List[CustomResourceDefinitionCondition]] = Field(
@@ -385,14 +385,14 @@ class CustomResourceDefinition(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ObjectMetaModel1] = Field(
-        {},
+        None,
         description="Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
     spec: CustomResourceDefinitionSpec = Field(
         ..., description='spec describes how the user wants the resources to appear'
     )
     status: Optional[CustomResourceDefinitionStatus] = Field(
-        {},
+        None,
         description='status indicates the actual state of the CustomResourceDefinition',
     )
 
@@ -410,7 +410,7 @@ class CustomResourceDefinitionList(BaseModel):
         description='Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     metadata: Optional[v1.ListMetaModel1] = Field(
-        {},
+        None,
         description="Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
     )
 

--- a/gybe/kubernetes/io/k8s/apimachinery/pkg/apis/meta/v1.py
+++ b/gybe/kubernetes/io/k8s/apimachinery/pkg/apis/meta/v1.py
@@ -4376,7 +4376,7 @@ class APIGroup(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscovery] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDR]] = Field(
@@ -4456,7 +4456,7 @@ class ObjectMeta(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[Time] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -4534,7 +4534,7 @@ class Status(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMeta] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -4566,7 +4566,7 @@ class APIGroupModel(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel]] = Field(
@@ -4657,7 +4657,7 @@ class ObjectMetaModel(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -4735,7 +4735,7 @@ class StatusModel(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -4767,7 +4767,7 @@ class APIGroupModel1(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel1] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel1]] = Field(
@@ -4804,7 +4804,7 @@ class APIGroupModel2(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel2] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel2]] = Field(
@@ -4827,7 +4827,7 @@ class APIGroupModel3(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel3] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel3]] = Field(
@@ -4907,7 +4907,7 @@ class ObjectMetaModel1(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel1] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -4985,7 +4985,7 @@ class StatusModel1(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel1] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -5017,7 +5017,7 @@ class APIGroupModel4(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel4] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel4]] = Field(
@@ -5097,7 +5097,7 @@ class ObjectMetaModel2(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel2] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -5175,7 +5175,7 @@ class StatusModel2(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel2] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -5207,7 +5207,7 @@ class APIGroupModel5(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel5] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel5]] = Field(
@@ -5230,7 +5230,7 @@ class APIGroupModel6(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel6] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel6]] = Field(
@@ -5310,7 +5310,7 @@ class ObjectMetaModel3(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel3] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -5388,7 +5388,7 @@ class StatusModel3(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel3] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -5488,7 +5488,7 @@ class ObjectMetaModel4(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel4] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -5566,7 +5566,7 @@ class StatusModel4(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel4] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -5655,7 +5655,7 @@ class ObjectMetaModel5(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel5] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -5733,7 +5733,7 @@ class StatusModel5(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel5] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -5765,7 +5765,7 @@ class APIGroupModel7(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel7] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel7]] = Field(
@@ -5845,7 +5845,7 @@ class ObjectMetaModel6(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel6] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -5923,7 +5923,7 @@ class StatusModel6(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel6] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -5981,7 +5981,7 @@ class ObjectMetaModel7(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel7] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -6049,7 +6049,7 @@ class APIGroupModel8(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel8] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel8]] = Field(
@@ -6140,7 +6140,7 @@ class ObjectMetaModel8(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel8] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -6218,7 +6218,7 @@ class StatusModel7(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel7] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -6307,7 +6307,7 @@ class ObjectMetaModel9(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel9] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -6385,7 +6385,7 @@ class StatusModel8(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel8] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -6417,7 +6417,7 @@ class APIGroupModel9(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel9] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[List[ServerAddressByClientCIDRModel9]] = Field(
@@ -6534,7 +6534,7 @@ class ObjectMetaModel10(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel10] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -6612,7 +6612,7 @@ class StatusModel9(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel9] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -6738,7 +6738,7 @@ class ObjectMetaModel11(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel11] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -6816,7 +6816,7 @@ class StatusModel10(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel10] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -6905,7 +6905,7 @@ class ObjectMetaModel12(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel12] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -6983,7 +6983,7 @@ class StatusModel11(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel11] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -7015,7 +7015,7 @@ class APIGroupModel10(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel10] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -7040,7 +7040,7 @@ class APIGroupModel11(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel11] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -7091,7 +7091,7 @@ class ObjectMetaModel13(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel13] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -7159,7 +7159,7 @@ class APIGroupModel12(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel12] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -7184,7 +7184,7 @@ class APIGroupModel13(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel13] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -7303,7 +7303,7 @@ class ObjectMetaModel14(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel14] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -7381,7 +7381,7 @@ class StatusModel12(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel12] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -7470,7 +7470,7 @@ class ObjectMetaModel15(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel15] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -7548,7 +7548,7 @@ class StatusModel13(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel13] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -7648,7 +7648,7 @@ class ObjectMetaModel16(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel16] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -7726,7 +7726,7 @@ class StatusModel14(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel14] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -7758,7 +7758,7 @@ class APIGroupModel14(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel14] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -7809,7 +7809,7 @@ class ObjectMetaModel17(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel17] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -7877,7 +7877,7 @@ class APIGroupModel15(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel15] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -7959,7 +7959,7 @@ class ObjectMetaModel18(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel18] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -8037,7 +8037,7 @@ class StatusModel15(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel15] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -8069,7 +8069,7 @@ class APIGroupModel16(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel16] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -8180,7 +8180,7 @@ class ObjectMetaModel19(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel19] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -8258,7 +8258,7 @@ class StatusModel16(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel16] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -8290,7 +8290,7 @@ class APIGroupModel17(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel17] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -8315,7 +8315,7 @@ class APIGroupModel18(BaseModel):
     )
     name: str = Field(..., description='name is the name of the group.')
     preferredVersion: Optional[GroupVersionForDiscoveryModel18] = Field(
-        {},
+        None,
         description='preferredVersion is the version preferred by the API server, which probably is the storage version.',
     )
     serverAddressByClientCIDRs: Optional[
@@ -8397,7 +8397,7 @@ class ObjectMetaModel20(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel20] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -8475,7 +8475,7 @@ class StatusModel17(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel17] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -8575,7 +8575,7 @@ class ObjectMetaModel21(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel21] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -8653,7 +8653,7 @@ class StatusModel18(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel18] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(
@@ -8753,7 +8753,7 @@ class ObjectMetaModel22(BaseModel):
         description='Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations',
     )
     creationTimestamp: Optional[TimeModel22] = Field(
-        {},
+        None,
         description='CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
     )
     deletionGracePeriodSeconds: Optional[int] = Field(
@@ -8831,7 +8831,7 @@ class StatusModel19(BaseModel):
         description='A human-readable description of the status of this operation.',
     )
     metadata: Optional[ListMetaModel19] = Field(
-        {},
+        None,
         description='Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds',
     )
     reason: Optional[str] = Field(


### PR DESCRIPTION
`datamodel-codegen` is setting the default value for sub-model fields to `{}` instead of `None`. This corrects that error. The root cause of this issue needs to be investigated.